### PR TITLE
Custom `Domain` type

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"fmt"
+
+	fssz "github.com/ferranbt/fastssz"
+)
+
+var _ fssz.HashRoot = (Domain)([]byte{})
+var _ fssz.Marshaler = (*Domain)(nil)
+var _ fssz.Unmarshaler = (*Domain)(nil)
+
+// Domain represents a 32 bytes domain object in Ethereum beacon chain consensus.
+type Domain []byte
+
+// HashTreeRoot returns calculated hash root.
+func (e Domain) HashTreeRoot() ([32]byte, error) {
+	return fssz.HashWithDefaultHasher(e)
+}
+
+// HashTreeRootWith hashes a Domain object with a Hasher from the default HasherPool.
+func (e Domain) HashTreeRootWith(hh *fssz.Hasher) error {
+	hh.PutBytes(e[:])
+	return nil
+}
+
+// UnmarshalSSZ deserializes the provided bytes buffer into the Domain object.
+func (e *Domain) UnmarshalSSZ(buf []byte) error {
+	if len(buf) != e.SizeSSZ() {
+		return fmt.Errorf("expected buffer of length %d received %d", e.SizeSSZ(), len(buf))
+	}
+
+	var b [32]byte
+	item := Domain(b[:])
+	copy(item, buf)
+	*e = item
+	return nil
+}
+
+// MarshalSSZTo marshals Domain with the provided byte slice.
+func (e *Domain) MarshalSSZTo(dst []byte) ([]byte, error) {
+	marshalled, err := e.MarshalSSZ()
+	if err != nil {
+		return nil, err
+	}
+	return append(dst, marshalled...), nil
+}
+
+// MarshalSSZ marshals Domain into a serialized object.
+func (e *Domain) MarshalSSZ() ([]byte, error) {
+	return *e, nil
+}
+
+// SizeSSZ returns the size of the serialized object.
+func (e *Domain) SizeSSZ() int {
+	return 32
+}

--- a/domain_test.go
+++ b/domain_test.go
@@ -1,0 +1,90 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDomain_Casting(t *testing.T) {
+	t.Run("empty byte slice", func(t *testing.T) {
+		b := make([]byte, 0)
+		d := Domain(b)
+		if !reflect.DeepEqual([]byte(d), b) {
+			t.Errorf("Unequal: %v = %v", d, b)
+		}
+	})
+
+	t.Run("non-empty byte slice", func(t *testing.T) {
+		b := make([]byte, 2)
+		b[0] = byte('a')
+		b[1] = byte('b')
+		d := Domain(b)
+		if !reflect.DeepEqual([]byte(d), b) {
+			t.Errorf("Unequal: %v = %v", d, b)
+		}
+	})
+
+	t.Run("byte array", func(t *testing.T) {
+		var b [2]byte
+		b[0] = byte('a')
+		b[1] = byte('b')
+		d := Domain(b[:])
+		if !reflect.DeepEqual([]byte(d), b[:]) {
+			t.Errorf("Unequal: %v = %v", d, b)
+		}
+	})
+}
+
+func TestDomain_UnmarshalSSZ(t *testing.T) {
+	t.Run("Ok", func(t *testing.T) {
+		d := Domain{}
+		var b = [32]byte{'f', 'o', 'o'}
+		err := d.UnmarshalSSZ(b[:])
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(b[:], []byte(d)) {
+			t.Errorf("Unequal: %v = %v", b, []byte(d))
+		}
+	})
+
+	t.Run("Wrong slice length", func(t *testing.T) {
+		d := Domain{}
+		var b = [16]byte{'f', 'o', 'o'}
+		err := d.UnmarshalSSZ(b[:])
+		if err == nil {
+			t.Error("Expected error")
+		}
+	})
+}
+
+func TestDomain_MarshalSSZTo(t *testing.T) {
+	d := Domain("foo")
+	dst := []byte("bar")
+	b, err := d.MarshalSSZTo(dst)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected := []byte("barfoo")
+	if !reflect.DeepEqual(expected, b) {
+		t.Errorf("Unequal: %v = %v", expected, b)
+	}
+}
+
+func TestDomain_MarshalSSZ(t *testing.T) {
+	d := Domain("foo")
+	b, err := d.MarshalSSZ()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(b[:], []byte(d)) {
+		t.Errorf("Unequal: %v = %v", b, []byte(d))
+	}
+}
+
+func TestDomain_SizeSSZ(t *testing.T) {
+	d := Domain{}
+	if d.SizeSSZ() !=32 {
+		t.Errorf("Wrong SSZ size. Expected %v vs actual %v", 32, d.SizeSSZ())
+	}
+}

--- a/domain_test.go
+++ b/domain_test.go
@@ -84,7 +84,7 @@ func TestDomain_MarshalSSZ(t *testing.T) {
 
 func TestDomain_SizeSSZ(t *testing.T) {
 	d := Domain{}
-	if d.SizeSSZ() !=32 {
+	if d.SizeSSZ() != 32 {
 		t.Errorf("Wrong SSZ size. Expected %v vs actual %v", 32, d.SizeSSZ())
 	}
 }

--- a/sszbytes_test.go
+++ b/sszbytes_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"encoding/hex"
 	"reflect"
 	"testing"
 
@@ -17,20 +16,20 @@ func TestSSZBytes_HashTreeRoot(t *testing.T) {
 	}{
 		{
 			name:        "random1",
-			actualValue: hexDecodeOrDie(t, "844e1063e0b396eed17be8eddb7eecd1fe3ea46542a4b72f7466e77325e5aa6d"),
-			root:        hexDecodeOrDie(t, "844e1063e0b396eed17be8eddb7eecd1fe3ea46542a4b72f7466e77325e5aa6d"),
+			actualValue: types.HexDecodeOrDie(t, "844e1063e0b396eed17be8eddb7eecd1fe3ea46542a4b72f7466e77325e5aa6d"),
+			root:        types.HexDecodeOrDie(t, "844e1063e0b396eed17be8eddb7eecd1fe3ea46542a4b72f7466e77325e5aa6d"),
 			wantErr:     false,
 		},
 		{
 			name:        "random1",
-			actualValue: hexDecodeOrDie(t, "7b16162ecd9a28fa80a475080b0e4fff4c27efe19ce5134ce3554b72274d59fd534400ba4c7f699aa1c307cd37c2b103"),
-			root:        hexDecodeOrDie(t, "128ed34ee798b9f00716f9ba5c000df5c99443dabc4d3f2e9bb86c77c732e007"),
+			actualValue: types.HexDecodeOrDie(t, "7b16162ecd9a28fa80a475080b0e4fff4c27efe19ce5134ce3554b72274d59fd534400ba4c7f699aa1c307cd37c2b103"),
+			root:        types.HexDecodeOrDie(t, "128ed34ee798b9f00716f9ba5c000df5c99443dabc4d3f2e9bb86c77c732e007"),
 			wantErr:     false,
 		},
 		{
 			name:        "random2",
 			actualValue: []byte{},
-			root:        hexDecodeOrDie(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+			root:        types.HexDecodeOrDie(t, "0000000000000000000000000000000000000000000000000000000000000000"),
 			wantErr:     false,
 		},
 	}
@@ -46,12 +45,4 @@ func TestSSZBytes_HashTreeRoot(t *testing.T) {
 			}
 		})
 	}
-}
-
-func hexDecodeOrDie(t *testing.T, str string) []byte {
-	decoded, err := hex.DecodeString(str)
-	if err != nil {
-		t.Errorf("hex.DecodeString(%s) unexpected error = %v", str, err)
-	}
-	return decoded
 }

--- a/sszuint64_test.go
+++ b/sszuint64_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"encoding/hex"
 	"reflect"
 	"strings"
 	"testing"
@@ -47,23 +46,23 @@ func TestSSZUint64(t *testing.T) {
 	}{
 		{
 			name:            "max",
-			serializedBytes: hexDecodeOrDie(t, "ffffffffffffffff"),
+			serializedBytes: types.HexDecodeOrDie(t, "ffffffffffffffff"),
 			actualValue:     18446744073709551615,
-			root:            hexDecodeOrDie(t, "ffffffffffffffff000000000000000000000000000000000000000000000000"),
+			root:            types.HexDecodeOrDie(t, "ffffffffffffffff000000000000000000000000000000000000000000000000"),
 			wantErr:         false,
 		},
 		{
 			name:            "random",
-			serializedBytes: hexDecodeOrDie(t, "357c8de9d7204577"),
+			serializedBytes: types.HexDecodeOrDie(t, "357c8de9d7204577"),
 			actualValue:     8594311575614880821,
-			root:            hexDecodeOrDie(t, "357c8de9d7204577000000000000000000000000000000000000000000000000"),
+			root:            types.HexDecodeOrDie(t, "357c8de9d7204577000000000000000000000000000000000000000000000000"),
 			wantErr:         false,
 		},
 		{
 			name:            "zero",
-			serializedBytes: hexDecodeOrDie(t, "0000000000000000"),
+			serializedBytes: types.HexDecodeOrDie(t, "0000000000000000"),
 			actualValue:     0,
-			root:            hexDecodeOrDie(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+			root:            types.HexDecodeOrDie(t, "0000000000000000000000000000000000000000000000000000000000000000"),
 			wantErr:         false,
 		},
 	}
@@ -94,12 +93,4 @@ func TestSSZUint64(t *testing.T) {
 			}
 		})
 	}
-}
-
-func hexDecodeOrDie(t *testing.T, str string) []byte {
-	decoded, err := hex.DecodeString(str)
-	if err != nil {
-		t.Errorf("hex.DecodeString(%s) unexpected error = %v", str, err)
-	}
-	return decoded
 }

--- a/test_helper.go
+++ b/test_helper.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func HexDecodeOrDie(t *testing.T, str string) []byte {
+	decoded, err := hex.DecodeString(str)
+	if err != nil {
+		t.Errorf("hex.DecodeString(%s) unexpected error = %v", str, err)
+	}
+	return decoded
+}


### PR DESCRIPTION
This PR introduces a new eth2 custom type: `type Domain []byte`. It also replaces duplicated function definition with a single function.