### PR TITLE
Simplify ssz encodings

### DIFF
--- a/committee_index.go
+++ b/committee_index.go
@@ -35,17 +35,13 @@ func (c *CommitteeIndex) UnmarshalSSZ(buf []byte) error {
 
 // MarshalSSZTo marshals committee index with the provided byte slice.
 func (c *CommitteeIndex) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := c.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = fssz.MarshalUint64(dst, uint64(*c))
+	return dst, nil
 }
 
 // MarshalSSZ marshals committee index into a serialized object.
 func (c *CommitteeIndex) MarshalSSZ() ([]byte, error) {
-	marshalled := fssz.MarshalUint64([]byte{}, uint64(*c))
-	return marshalled, nil
+	return fssz.MarshalSSZ(c)
 }
 
 // SizeSSZ returns the size of the serialized object.

--- a/domain.go
+++ b/domain.go
@@ -39,16 +39,13 @@ func (e *Domain) UnmarshalSSZ(buf []byte) error {
 
 // MarshalSSZTo marshals Domain with the provided byte slice.
 func (e *Domain) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := e.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = append(dst, (*e)[:]...)
+	return dst, nil
 }
 
 // MarshalSSZ marshals Domain into a serialized object.
 func (e *Domain) MarshalSSZ() ([]byte, error) {
-	return *e, nil
+	return fssz.MarshalSSZ(e)
 }
 
 // SizeSSZ returns the size of the serialized object.

--- a/epoch.go
+++ b/epoch.go
@@ -132,17 +132,13 @@ func (e *Epoch) UnmarshalSSZ(buf []byte) error {
 
 // MarshalSSZTo marshals epoch with the provided byte slice.
 func (e *Epoch) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := e.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = fssz.MarshalUint64(dst, uint64(*e))
+	return dst, nil
 }
 
 // MarshalSSZ marshals epoch into a serialized object.
 func (e *Epoch) MarshalSSZ() ([]byte, error) {
-	marshalled := fssz.MarshalUint64([]byte{}, uint64(*e))
-	return marshalled, nil
+	return fssz.MarshalSSZ(e)
 }
 
 // SizeSSZ returns the size of the serialized object.

--- a/slot.go
+++ b/slot.go
@@ -180,17 +180,13 @@ func (s *Slot) UnmarshalSSZ(buf []byte) error {
 
 // MarshalSSZTo marshals slot with the provided byte slice.
 func (s *Slot) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := s.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = fssz.MarshalUint64(dst, uint64(*s))
+	return dst, nil
 }
 
 // MarshalSSZ marshals slot into a serialized object.
 func (s *Slot) MarshalSSZ() ([]byte, error) {
-	marshalled := fssz.MarshalUint64([]byte{}, uint64(*s))
-	return marshalled, nil
+	return fssz.MarshalSSZ(s)
 }
 
 // SizeSSZ returns the size of the serialized object.

--- a/sszuint64.go
+++ b/sszuint64.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	fssz "github.com/ferranbt/fastssz"
@@ -21,17 +20,13 @@ func (s *SSZUint64) SizeSSZ() int {
 
 // MarshalSSZTo marshals the uint64 with the provided byte slice.
 func (s *SSZUint64) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := s.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = fssz.MarshalUint64(dst, uint64(*s))
+	return dst, nil
 }
 
 // MarshalSSZ marshals uin64 into a serialized object.
 func (s *SSZUint64) MarshalSSZ() ([]byte, error) {
-	marshalled := fssz.MarshalUint64([]byte{}, uint64(*s))
-	return marshalled, nil
+	return fssz.MarshalSSZ(s)
 }
 
 // UnmarshalSSZ deserializes the provided bytes buffer into the uint64 object.
@@ -45,17 +40,11 @@ func (s *SSZUint64) UnmarshalSSZ(buf []byte) error {
 
 // HashTreeRoot returns calculated hash root.
 func (s *SSZUint64) HashTreeRoot() ([32]byte, error) {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, uint64(*s))
-	var root [32]byte
-	copy(root[:], buf)
-	return root, nil
+	return fssz.HashWithDefaultHasher(s)
 }
 
 // HashWithDefaultHasher hashes a HashRoot object with a Hasher from the default HasherPool.
 func (s *SSZUint64) HashTreeRootWith(hh *fssz.Hasher) error {
-	indx := hh.Index()
 	hh.PutUint64(uint64(*s))
-	hh.Merkleize(indx)
 	return nil
 }

--- a/validator.go
+++ b/validator.go
@@ -61,17 +61,13 @@ func (v *ValidatorIndex) UnmarshalSSZ(buf []byte) error {
 
 // MarshalSSZTo marshals validator index with the provided byte slice.
 func (v *ValidatorIndex) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalled, err := v.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalled...), nil
+	dst = fssz.MarshalUint64(dst, uint64(*v))
+	return dst, nil
 }
 
 // MarshalSSZ marshals validator index into a serialized object.
 func (v *ValidatorIndex) MarshalSSZ() ([]byte, error) {
-	marshalled := fssz.MarshalUint64([]byte{}, uint64(*v))
-	return marshalled, nil
+	return fssz.MarshalSSZ(v)
 }
 
 // SizeSSZ returns the size of the serialized object.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR simplifies the ssz encodings for some of the structs and aligns them with the ones generated by fssz, among other things it follows the next patterns:

- ```MarshalSSZ``` always calls ```MarshalSSZTo```.
- ```HashTreeRoot``` always calls ```HashTreeRootWith```.
- Always copy values to ```dst``` and do not pass them by reference ([]bytes).

These changes are important to keep a standard among all the encodings and have zero-memory allocations.
